### PR TITLE
Minor bug fix.

### DIFF
--- a/Clauses/RepeatingClauseParser.cs
+++ b/Clauses/RepeatingClauseParser.cs
@@ -35,9 +35,6 @@ public class RepeatingClauseParser : ClauseParser, IClauseParserParent
         _min = min;
         _max = max;
         _errorMessage = errorMessage;
-
-        if (_wrapped is ExpressionClauseParser expressionClauseParser && min == 0)
-            expressionClauseParser.SetIsOptional(true);
     }
 
     /// <summary>
@@ -55,6 +52,9 @@ public class RepeatingClauseParser : ClauseParser, IClauseParserParent
 
         while (true)
         {
+            if (_wrapped is ExpressionClauseParser expressionClauseParser)
+                expressionClauseParser.SetIsOptional(expressions.Count >= _min);
+
             Clause wrappedResult = _wrapped.TryParse(parser);
 
             if (wrappedResult != null)

--- a/Lex.csproj
+++ b/Lex.csproj
@@ -16,7 +16,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageReleaseNotes>https://github.com/jskress/Lex/blob/main/docs/release-notes.md</PackageReleaseNotes>
         <PackageTags>dsl lexical parser tokens clauses expressions</PackageTags>
-        <Version>1.1.0</Version>
+        <Version>1.1.0.1</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,9 @@
 ## Release Notes
 
+### 1.1.0.1
+
+- Minor bug fix relating to wrapping an expression clause with a repeating clause.
+
 ### 1.1.0
 
 - Added support for an expression clause, allowing expressions to be expected in the


### PR DESCRIPTION
There was a bug when wrapping an expression clause with a repetition clause relating to when the expression is required and when it isn't.  This has been fixed.