### PR TITLE
Much better support for self- and cross-referencing clauses.

### DIFF
--- a/Clauses/ClauseParser.cs
+++ b/Clauses/ClauseParser.cs
@@ -58,10 +58,13 @@ public abstract class ClauseParser
     /// <returns>This object, for fluency.</returns>
     public ClauseParser SetDebugging(bool newState)
     {
-        IsDebugging = newState;
+        if (IsDebugging != newState)
+        {
+            IsDebugging = newState;
 
-        if (this is IClauseParserParent parent)
-            parent.Children.ForEach(child => child.SetDebugging(newState));
+            if (this is IClauseParserParent parent)
+                parent.Children.ForEach(child => child.SetDebugging(newState));
+        }
 
         return this;
     }

--- a/Dsl/DslParsingContext.cs
+++ b/Dsl/DslParsingContext.cs
@@ -1,0 +1,55 @@
+using Lex.Clauses;
+using Lex.Parser;
+using Lex.Tokens;
+
+namespace Lex.Dsl;
+
+/// <summary>
+/// This record carries the information we need while we are parsing source DSL.
+/// </summary>
+/// <param name="Stored">The clause parser that is stored; i.e., the "official" one.</param>
+/// <param name="Parser">The claude parser that needs to be populated later.</param>
+/// <param name="Tokens">The list of tokens that define the clause</param>
+/// <param name="Debug">The debug flag to set once the clause has been populated.</param>
+internal record ClauseParserSource<TParser>(
+    ClauseParser Stored, TParser Parser, List<Token> Tokens, bool Debug) 
+    where TParser : ClauseParser;
+
+/// <summary>
+/// This class is a carrier for all the things we care about while parsing a DSL
+/// specification.
+/// </summary>
+internal class DslParsingContext
+{
+    /// <summary>
+    /// This property holds the parser that is being used to parse the DSL specification.
+    /// </summary>
+    internal LexicalParser Parser { get; init; }
+
+    /// <summary>
+    /// This property holds the set of variables we are using.
+    /// </summary>
+    internal Dictionary<string, object> Variables { get; init; }
+
+    /// <summary>
+    /// This property holds the list of tokens that make up the clause to process.
+    /// </summary>
+    internal List<Token> Tokens { get; set; }
+
+    /// <summary>
+    /// The DSL we are building up.
+    /// </summary>
+    internal Dsl Dsl { get; init; }
+
+    /// <summary>
+    /// This property holds a list of deferred token lists to use in populating sequential
+    /// clauses.
+    /// </summary>
+    internal List<ClauseParserSource<SequentialClauseParser>> SequentialClauseSources { get; } = [];
+
+    /// <summary>
+    /// This property holds a list of deferred token lists to use in populating switch
+    /// clauses.
+    /// </summary>
+    internal List<ClauseParserSource<SwitchClauseParser>> SwitchClauseSources { get; } = [];
+}

--- a/Lex.csproj
+++ b/Lex.csproj
@@ -16,7 +16,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageReleaseNotes>Full release notes may be found here: https://github.com/jskress/Lex/blob/main/docs/release-notes.md</PackageReleaseNotes>
         <PackageTags>dsl lexical parser tokens clauses expressions</PackageTags>
-        <Version>1.1.2.1</Version>
+        <Version>1.1.3</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Tests/ClauseTests/RecursiveClauseReferenceTests.cs
+++ b/Tests/ClauseTests/RecursiveClauseReferenceTests.cs
@@ -11,21 +11,26 @@ public class RecursiveClauseReferenceTests
     public void TestRecursiveClauseReference()
     {
         Dsl dsl = LexicalDslFactory.CreateFrom("""
-            _keywords: 'test'
-            testClause: {}
-            testClause: { test }
+            childClause: { parentClause }
+            parentClause: { childClause }
             """);
         FieldInfo info = dsl.GetType().GetField(
             "_clauses", BindingFlags.NonPublic | BindingFlags.Instance);
         Dictionary<string, ClauseParser> clauses = (Dictionary<string, ClauseParser>) info!.GetValue(dsl);
 
         Assert.IsNotNull(clauses);
-        Assert.AreEqual(1, clauses.Count);
-        Assert.IsTrue(clauses.ContainsKey("testClause"));
+        Assert.AreEqual(2, clauses.Count);
+        Assert.IsTrue(clauses.ContainsKey("parentClause"));
+        Assert.IsTrue(clauses.ContainsKey("childClause"));
 
-        SequentialClauseParser sequentialClauseParser = clauses["testClause"] as SequentialClauseParser;
+        SequentialClauseParser parentClause = clauses["parentClause"] as SequentialClauseParser;
+        SequentialClauseParser childClause = clauses["childClause"] as SequentialClauseParser;
 
-        Assert.IsNotNull(sequentialClauseParser);
-        Assert.AreEqual(1, sequentialClauseParser.Children.Count);
+        Assert.IsNotNull(parentClause);
+        Assert.IsNotNull(childClause);
+        Assert.AreEqual(1, parentClause.Children.Count);
+        Assert.AreEqual(1, childClause.Children.Count);
+        Assert.AreSame(parentClause, childClause.Children[0]);
+        Assert.AreSame(childClause, parentClause.Children[0]);
     }
 }

--- a/Tests/LexicalParserDslTests/BasedNumberTokenizerConfigurationTests.cs
+++ b/Tests/LexicalParserDslTests/BasedNumberTokenizerConfigurationTests.cs
@@ -7,9 +7,9 @@ public class BasedNumberTokenizerConfigurationTests : LexicalParserDslTestsBase
 {
     private static readonly List<ErrorEntry> ErrorTests =
     [
-        // new ErrorEntry("based", "Expecting \"numbers\" after \"based\" here."),
-        // new ErrorEntry("based numbers no", "Expecting \"hex\", \"octal\" or \"binary\" after \"no\" here."),
-        // new ErrorEntry("based numbers no or", "Expecting \"hex\", \"octal\" or \"binary\" after \"no\" here."),
+        new ErrorEntry("based", "Expecting \"numbers\" to follow \"based\" here."),
+        new ErrorEntry("based numbers no", "Expecting \"hex\", \"octal\" or \"binary\" to follow \"no\" here."),
+        new ErrorEntry("based numbers no or", "Expecting \"hex\", \"octal\" or \"binary\" to follow \"no\" here."),
         new ErrorEntry("based numbers no hex no hex", "The \"no hex\" clause has already been specified.")
     ];
 

--- a/docs/dsl-specification-dsl.md
+++ b/docs/dsl-specification-dsl.md
@@ -32,15 +32,6 @@ specification looks like this:
   <img alt="Top level DSL factory DSL" src="images/dsl-dsl/top-level.png">
 </picture>
 
-When defining named sequential or switch clauses, there may be times when circular
-references, which may take the form of two clauses that refer to each other, or a clause
-that needs to refer to itself, are required.  You support this by specifying the definition
-of the clause twice.  The first time, the clause must be defined empty.  The second
-time should contain the full definition.  If you need to enable debugging for a clause in
-this case, do so on the second occurrence, not the first.  When the DSL factory finds this
-situation, it takes the second declaration as a continuation of the first.  **Note:** use
-such clauses with care as the grammar can become problematic.
-
 You may specify one, and only one, switch clause without a leading label that will act as
 the top-level clause parser for the DSL.  Typically, this will contain the clause parsers
 for each of your top-level language constructs.  You will likely want to include a tag for

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,12 +1,17 @@
 ## Release Notes
 
+### 1.1.3
+
+- Found a better way to support self- or cross-referencing clauses that doesn't require
+  forward declarations.
+
 ### 1.1.2.1
 
-- Fixed an issue with self-contained or recursive clause definitions to the DSL DSl.
+- Fixed an issue with self- or cross-referencing clause definitions to the DSL DSl.
 
 ### 1.1.2
 
-- Added support for self-contained or recursive clause definitions to the DSL DSl.
+- Added support for self- or cross-referencing clause definitions to the DSL DSl.
 
 ### 1.1.1
 


### PR DESCRIPTION
No more forward referencing required.  We now defer actual population of sequential and switch named clauses until after the whole source has been parsed.  This allows forward references (references to clauses not yet defined), cross-references (where two clauses, directly or indirectly, refer to each other) and self-references (where a clause refers to itself somewhere).