### PR TITLE
Fixed not creating expression clause parsers.

### DIFF
--- a/Dsl/LexicalDslFactory.cs
+++ b/Dsl/LexicalDslFactory.cs
@@ -706,6 +706,7 @@ public static partial class LexicalDslFactory
             }
 
             parser = new ExpressionClauseParser(context.Dsl.ExpressionParser);
+            token = null;
         }
         // Handle built-in type usage.
         else if (text[0] == '_' && TokenTypesMap.TryGetValue(text, out type))

--- a/Lex.csproj
+++ b/Lex.csproj
@@ -16,7 +16,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageReleaseNotes>Full release notes may be found here: https://github.com/jskress/Lex/blob/main/docs/release-notes.md</PackageReleaseNotes>
         <PackageTags>dsl lexical parser tokens clauses expressions</PackageTags>
-        <Version>1.1.3.1</Version>
+        <Version>1.1.3.2</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,9 @@
 ## Release Notes
 
+### 1.1.3.2
+
+- Fixed an issue with expression clause parsers not being properly created.
+
 ### 1.1.3.1
 
 - Fixed an issue with using multiple types of string tokenizers in the parser DSL.


### PR DESCRIPTION
When parsing a DSL spec, the `_expression` marker was not being correctly converted to an expression clause parser.  This has been fixed.