### PR TITLE
Fixed an issue with parsing expressions via clauses.

### DIFF
--- a/Clauses/ExpressionClauseParser.cs
+++ b/Clauses/ExpressionClauseParser.cs
@@ -45,6 +45,7 @@ public class ExpressionClauseParser : ClauseParser
 
         return new Clause
         {
+            Tokens = [],
             Expressions = [expression]
         };
     }

--- a/Lex.csproj
+++ b/Lex.csproj
@@ -16,7 +16,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageReleaseNotes>Full release notes may be found here: https://github.com/jskress/Lex/blob/main/docs/release-notes.md</PackageReleaseNotes>
         <PackageTags>dsl lexical parser tokens clauses expressions</PackageTags>
-        <Version>1.1.3.2</Version>
+        <Version>1.1.3.3</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,10 @@
 ## Release Notes
 
+### 1.1.3.3
+
+- Fixed an issue with parsing expressions through clauses.  A new test was added to make
+  sure things work right.
+
 ### 1.1.3.2
 
 - Fixed an issue with expression clause parsers not being properly created.


### PR DESCRIPTION
When an expression clause parser was referenced by a wrapping clause, an NRE was resulting.  This has been fixed.  A new test has been aded to make sure expression parsing from a DSL specification works as required.