### PR TITLE
Fixed parsing of terms with nested expressions.

### DIFF
--- a/Expressions/ExpressionParser.cs
+++ b/Expressions/ExpressionParser.cs
@@ -350,7 +350,7 @@ public class ExpressionParser
     }
 
     /// <summary>
-    /// This is a helper method for gathering up a list of unary operators.
+    /// This is a helper method for gathering a list of unary operators.
     /// </summary>
     /// <param name="parser">The parser to read from.</param>
     /// <param name="set">The unary operator collection to use.</param>
@@ -421,19 +421,21 @@ public class ExpressionParser
     private IExpressionTerm ParseFundamentalTerm(LexicalParser parser, bool optional)
     {
         Token token = parser.PeekNextToken();
-        IExpressionTerm term = _termChoiceParsers
-            .Select(termChoice => termChoice.TryParse(this, parser))
-            .FirstOrDefault(t => t != null);
 
-        if (term == null && !optional)
+        foreach (var term in _termChoiceParsers
+                     .Select(termChoiceParser => termChoiceParser.TryParse(this, parser))
+                     .Where(term => term != null))
         {
-            throw new TokenException(ResolveMessage(ExpressionParseMessageTypes.MissingRequiredTerm))
-            {
-                Token = token
-            };
+            return term;
         }
 
-        return term;
+        if (optional)
+            return null;
+
+        throw new TokenException(ResolveMessage(ExpressionParseMessageTypes.MissingRequiredTerm))
+        {
+            Token = token
+        };
     }
 
     /// <summary>

--- a/Lex.csproj
+++ b/Lex.csproj
@@ -16,7 +16,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageReleaseNotes>Full release notes may be found here: https://github.com/jskress/Lex/blob/main/docs/release-notes.md</PackageReleaseNotes>
         <PackageTags>dsl lexical parser tokens clauses expressions</PackageTags>
-        <Version>1.1.3.3</Version>
+        <Version>1.1.3.4</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,10 @@
 ## Release Notes
 
+### 1.1.3.4
+
+- Fixed an issue with parsing expression terms that contain nested expressions.  Yes, it
+  includes a new test.
+
 ### 1.1.3.3
 
 - Fixed an issue with parsing expressions through clauses.  A new test was added to make


### PR DESCRIPTION
When parsing expressions, the wrong (usually `null`) term choice parser could be chosen which led to bad things.  This has been fixed (including a supporting test).