### PR TITLE
Fixed issues with tagging inside a switch clause.

### DIFF
--- a/Dsl/LexicalDslFactory.cs
+++ b/Dsl/LexicalDslFactory.cs
@@ -507,6 +507,11 @@ public static partial class LexicalDslFactory
         // need to be a repeat clause.
         index = Math.Min(index + 1, tokens.Count);
 
+        if (index < tokens.Count - 1 &&
+            OperatorToken.Coalesce.Matches(tokens[index]) &&
+            tokens[index + 1] is StringToken)
+            index += 2;
+
         return (tokens[..index], tokens[index..]);
     }
 
@@ -557,16 +562,16 @@ public static partial class LexicalDslFactory
             if (token != null)
             {
                 if (first)
-                    parser.Matching(errorMessage, tag, token);
+                    parser.Matching(tag, errorMessage, token);
                 else
-                    parser.Or(errorMessage, tag, token);
+                    parser.Or(tag, errorMessage, token);
             }
             else if (type != null)
             {
                 if (first)
-                    parser.Matching(errorMessage, tag, type);
+                    parser.Matching(tag, errorMessage, type);
                 else
-                    parser.Or(errorMessage, tag, type);
+                    parser.Or(tag, errorMessage, type);
             }
             else
             {

--- a/Lex.csproj
+++ b/Lex.csproj
@@ -16,7 +16,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageReleaseNotes>Full release notes may be found here: https://github.com/jskress/Lex/blob/main/docs/release-notes.md</PackageReleaseNotes>
         <PackageTags>dsl lexical parser tokens clauses expressions</PackageTags>
-        <Version>1.1.3.4</Version>
+        <Version>1.1.4</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Tests/ClauseTests/ClauseDslTests.cs
+++ b/Tests/ClauseTests/ClauseDslTests.cs
@@ -1,0 +1,49 @@
+using Lex;
+using Lex.Clauses;
+using Lex.Dsl;
+using Lex.Parser;
+
+namespace Tests.ClauseTests;
+
+[TestClass]
+public class ClauseDslTests : TestsBase
+{
+    [TestMethod]
+    public void TestRecursiveClauseReference()
+    {
+        Dsl dsl = LexicalDslFactory.CreateFrom(""""
+            _parserSpec: """
+                dsl keywords
+                whitespace
+                """
+            _keywords: 'one', 'two', 'three', 'four'
+            clause: [ one | two | three ] ?? 'Boom!' 
+            """");
+        LexicalParser parser = dsl.CreateLexicalParser();
+
+        parser.SetSource("four".AsReader());
+        
+        AssertTokenException(() => dsl.ParseClause(parser, "clause"),
+            "Boom!");
+    }
+
+    [TestMethod]
+    public void TestTokenClauseTagging()
+    {
+        Dsl dsl = LexicalDslFactory.CreateFrom(""""
+            _parserSpec: """
+                dsl keywords
+                whitespace
+                """
+            _keywords: 'background'
+            [ background => 'the background' ] ?? 'Boom!' 
+            """");
+        LexicalParser parser = dsl.CreateLexicalParser();
+
+        parser.SetSource("background".AsReader());
+
+        Clause clause = dsl.ParseNextClause(parser);
+
+        Assert.AreEqual("the background", clause.Tag);
+    }
+}

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,21 +1,15 @@
 ## Release Notes
 
-### 1.1.3.4
+### 1.1.4
 
+- Fixed two issues with switch clause tagging.
 - Fixed an issue with parsing expression terms that contain nested expressions.  Yes, it
   includes a new test.
-
-### 1.1.3.3
-
+- Fixed an issue with parsing expression terms that contain nested expressions.  Yes, it
+  includes a new test.
 - Fixed an issue with parsing expressions through clauses.  A new test was added to make
   sure things work right.
-
-### 1.1.3.2
-
 - Fixed an issue with expression clause parsers not being properly created.
-
-### 1.1.3.1
-
 - Fixed an issue with using multiple types of string tokenizers in the parser DSL.
 - Fixed an issue where a simple number was not allowed in a repeat clause.
 


### PR DESCRIPTION
If a choice in a switch clause was a toke or type, instead of a sub-clause, it would not be properly tagged.  The error message for a named clause was not being set properly.  These have been fixed.