### PR TITLE
Fix equal-precedence operator grouping; release 1.2.1

### DIFF
--- a/Expressions/ExpressionParser.cs
+++ b/Expressions/ExpressionParser.cs
@@ -277,19 +277,33 @@ public class ExpressionParser
     }
 
     /// <summary>
-    /// This method looks at the last two operators and, if the next to last one has a
+    /// This method looks at the last two operators and, while the next to last one has a
     /// precedence that is the same or larger than the last one, the next to last is
     /// combined into a single term.
     /// </summary>
+    /// <remarks>
+    /// It keeps going rather than reducing once, and that is the whole of what makes the final
+    /// reduction correct.  The list of operators is meant to hold precedences that rise strictly
+    /// from left to right -- that is the invariant the last pass leans on when it reduces from the
+    /// right -- and one reduction can leave the invariant broken.  Reducing the last pair of
+    /// <c>[minus, divide, minus]</c> gives <c>[minus, minus]</c>, which is not strictly rising, and
+    /// the last pass then groups that equal pair from the right: <c>a - (b / c - d)</c> where
+    /// <c>(a - b / c) - d</c> was written.  That is not a near miss, it is a different sum.
+    /// </remarks>
     /// <param name="terms">The current set of terms in the expression.</param>
     /// <param name="operators">The current set of operators in the expression.</param>
     private void TryToReduce(List<IExpressionTerm> terms, List<Operator> operators)
     {
-        int index1 = operators.Count - 2;
-        int index2 = index1 + 1;
+        while (operators.Count > 1)
+        {
+            int index1 = operators.Count - 2;
+            int index2 = index1 + 1;
 
-        if (operators[index1] >= operators[index2])
+            if (!(operators[index1] >= operators[index2]))
+                break;
+
             DoBinaryReduction(terms, operators, index1);
+        }
     }
 
     /// <summary>

--- a/Lex.csproj
+++ b/Lex.csproj
@@ -16,7 +16,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageReleaseNotes>Full release notes may be found here: https://github.com/jskress/Lex/blob/main/docs/release-notes.md</PackageReleaseNotes>
         <PackageTags>dsl lexical parser tokens clauses expressions</PackageTags>
-        <Version>1.2.0</Version>
+        <Version>1.2.1</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Tests/ExpressionTests/ExpressionTests.cs
+++ b/Tests/ExpressionTests/ExpressionTests.cs
@@ -444,6 +444,39 @@ public class ExpressionTests
             testCase.Run();
     }
 
+    [TestMethod]
+    public void TestOperatorsOfEqualPrecedenceGroupLeftToRight()
+    {
+        // Reducing keeps a stack of operators whose precedences are meant to rise strictly from left
+        // to right, because the last step then reduces from the right and gets the answer.  What broke
+        // that is a stack of three where reducing the last pair leaves the first two *equal*: the
+        // check ran once and stopped, the invariant was gone, and the final pass grouped the equal
+        // pair the wrong way round.
+        //
+        // "1 - 2 / 2 - 3" is the shortest thing that does it, and it wants ((1 - (2 / 2)) - 3).  It was
+        // coming out (1 - ((2 / 2) - 3)) -- which is not a rounding difference, it is a different sum:
+        // -1 as against 3.
+        foreach ((string source, string expected) in new[]
+                 {
+                     ("1 - 2 / 2 - 3", "(((1) - ((2) / (2))) - (3))"),
+                     ("1 - 2 - 3", "(((1) - (2)) - (3))"),
+                     ("1 - 2 * 3 - 4", "(((1) - ((2) * (3))) - (4))"),
+                     ("1 + 2 / 2 + 3", "(((1) + ((2) / (2))) + (3))"),
+                     ("8 / 4 / 2", "(((8) / (4)) / (2))"),
+                     ("1 - 2 - 3 - 4", "((((1) - (2)) - (3)) - (4))"),
+                     ("1 - 2 / 2 - 3 / 3 - 4",
+                         "((((1) - ((2) / (2))) - ((3) / (3))) - (4))"),
+
+                     // The cases that were already right, kept so a fix cannot trade one for another.
+                     ("1 - 2 * 3", "((1) - ((2) * (3)))"),
+                     ("1 * 2 - 3", "(((1) * (2)) - (3))"),
+                     ("1 * 2 - 3 * 4", "(((1) * (2)) - ((3) * (4)))")
+                 })
+        {
+            Assert.AreEqual(expected, ParseToTerm(source).Text, $"parsing \"{source}\"");
+        }
+    }
+
     private static DefaultExpressionTerm ParseToTerm(string source)
     {
         Dsl dsl = LexicalDslFactory.CreateFrom(DslSpec);

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,15 @@
 ## Release Notes
 
+### 1.2.1
+
+- Bug fixes:
+  - Fixed expressions that mix operators of equal precedence with a higher-precedence
+    operator between them being grouped right-to-left instead of left-to-right.  Reducing the
+    pending operators stopped after a single reduction, which could leave two equal-precedence
+    operators adjacent, and the final pass then grouped that pair from the right.  For
+    example, `1 - 2 / 2 - 3` parsed as `1 - ((2 / 2) - 3)`, which evaluates to -1, instead of
+    `(1 - (2 / 2)) - 3`, which evaluates to 3.
+
 ### 1.2.0
 
 - Added the [`ClauseDispatcher`](../Clauses/ClauseDispatcher.cs) and


### PR DESCRIPTION
## The bug

Reducing the pending operator stack stopped after a single reduction. That could leave two
equal-precedence operators adjacent, breaking the invariant the final pass relies on (precedences
rising strictly left to right), and the final pass then grouped that pair from the *right*.

`1 - 2 / 2 - 3` parsed as `1 - ((2 / 2) - 3)` instead of `(1 - (2 / 2)) - 3` — evaluating to -1
rather than 3. Not a near miss; a different answer.

## The fix

`ExpressionParser.TryToReduce()` now loops until the invariant holds, instead of reducing once.

## Release

Version bumped to **1.2.1** with a release-notes entry, for publishing to NuGet.

## Testing

Full suite passes: 118 tests, 0 failures. The new `TestOperatorsOfEqualPrecedenceGroupLeftToRight`
covers the failing shape and its variants, plus the cases that already worked so a fix can't trade
one for another.

🤖 Generated with [Claude Code](https://claude.com/claude-code)